### PR TITLE
1fix remote

### DIFF
--- a/backup-config-pb.yml
+++ b/backup-config-pb.yml
@@ -25,3 +25,4 @@
   - name: backup running config to file
     ios_config:
       backup: yes
+    tags: backup

--- a/backup-config-pb.yml
+++ b/backup-config-pb.yml
@@ -7,17 +7,17 @@
 
 
   tasks:
-# ##  VERIFIED EXCEPT FOR WHEN STATEMENT
-#   - name: SAVING CONFIGS
-#     ntc_save_config:
-#        platform: cisco_ios_ssh
-#        host: "{{ ansible_host }}"
-#        username: "{{ ansible_user }}"
-#        password: "{{ ansible_ssh_pass }}"
-#        local_file: backups/CONFIG_{{ ansible_host }}.cfg
-#     when: 
-#       - not stop_process
-#     tags: backup
+##  VERIFIED EXCEPT FOR WHEN STATEMENT
+  - name: SAVING CONFIGS
+    ntc_save_config:
+       platform: cisco_ios_ssh
+       host: "{{ ansible_host }}"
+       username: "{{ ansible_user }}"
+       password: "{{ ansible_ssh_pass }}"
+       local_file: backups/CONFIG_{{ ansible_host }}.cfg
+    when: 
+      - not stop_process
+    tags: backup
 
 
 ### VERIFIED


### PR DESCRIPTION
this added the flag in addition to the 2nd backup routine
this was tracking 1fix-branch, but then i changed the name of the local branch.
It came through as as separate branch in the share repo when I pushed it up
